### PR TITLE
Fix Railway deployment for monorepo

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,10 +2,10 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "cd apps/api && npm install"
+    "buildCommand": "pnpm install --filter=datatrace-api"
   },
   "deploy": {
-    "startCommand": "cd apps/api && npm start",
+    "startCommand": "pnpm --filter=datatrace-api start",
     "healthcheckPath": "/",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
The previous `railway.json` configuration was attempting to build the `apps/api` service by `cd`-ing into the directory and running `npm install`. This is incorrect for a shared monorepo with npm workspaces.

This change updates `railway.json` to use `pnpm` (as indicated by the `pnpm-lock.yaml` file) and its workspace features to correctly build and start the `api` service.

The build command is changed to `pnpm install --filter=datatrace-api` to install dependencies for only the `api` service from the root of the repository.

The start command is changed to `pnpm --filter=datatrace-api start` to run the start script of the `api` service.

This change is based on the official Railway documentation for deploying shared monorepos and should fix the deployment failures. No local tests were run as this change can only be verified by deploying to Railway.