### PR TITLE
Improve dashboard responsiveness

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,16 +1,18 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { useAuth } from "@/hooks/use-auth"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
-import { 
-  User, 
-  Search, 
+import {
+  Search,
   LogOut,
   Home,
-  Brain
+  Brain,
+  Menu,
+  X
 } from "lucide-react"
 import { usePathname, useRouter } from "next/navigation"
 import Link from "next/link"
@@ -23,6 +25,7 @@ export default function DashboardLayout({
   const { user, logout } = useAuth()
   const pathname = usePathname()
   const router = useRouter()
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   if (!user) {
     return null
@@ -35,11 +38,21 @@ export default function DashboardLayout({
 
   const isActive = (path: string) => pathname === path
 
+  useEffect(() => {
+    setIsMobileMenuOpen(false)
+  }, [pathname])
+
+  const toggleMobileMenu = () => setIsMobileMenuOpen((prev) => !prev)
+
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <div className="flex min-h-screen flex-col bg-gray-50 lg:flex-row">
       {/* Left Sidebar */}
-      <div className="w-80 bg-white shadow-lg border-r border-gray-200">
-        <div className="p-6">
+      <div
+        className={`fixed inset-y-0 left-0 z-40 w-72 transform bg-white shadow-xl border-r border-gray-200 transition-transform duration-300 ease-in-out lg:static lg:w-80 lg:translate-x-0 lg:shadow-lg ${
+          isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="flex h-full flex-col overflow-y-auto px-6 py-6">
           {/* User Profile Section */}
           <div className="text-center mb-6">
             <Avatar className="w-16 h-16 mx-auto mb-3">
@@ -128,9 +141,47 @@ export default function DashboardLayout({
       </div>
 
       {/* Main content */}
-      <div className="flex-1">
-        {children}
+      <div className="flex-1 lg:ml-0">
+        <header className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-4 shadow-sm lg:hidden">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={toggleMobileMenu}
+              aria-label={isMobileMenuOpen ? 'Закрыть меню' : 'Открыть меню'}
+            >
+              {isMobileMenuOpen ? (
+                <X className="h-5 w-5" />
+              ) : (
+                <Menu className="h-5 w-5" />
+              )}
+            </Button>
+            <div>
+              <p className="text-sm font-semibold text-gray-900">
+                {user.name || user.email}
+              </p>
+              <p className="text-xs text-gray-500">Личный кабинет</p>
+            </div>
+          </div>
+          <Avatar className="h-9 w-9">
+            <AvatarImage src={user.avatar || ""} />
+            <AvatarFallback className="bg-blue-100 text-blue-600 text-sm">
+              {user.email?.charAt(0).toUpperCase() || 'U'}
+            </AvatarFallback>
+          </Avatar>
+        </header>
+        <div className="flex-1">
+          {children}
+        </div>
       </div>
+
+      {/* Overlay */}
+      {isMobileMenuOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/40 backdrop-blur-sm lg:hidden"
+          onClick={() => setIsMobileMenuOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -351,7 +351,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="px-4 py-6 sm:px-6 lg:px-8">
+    <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
       {/* Payment Success Alert */}
       {paymentSuccess && (
         <Alert className="mb-6 border-green-200 bg-green-50">
@@ -412,10 +412,10 @@ export default function Dashboard() {
       </div>
 
       {/* Quick Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+      <div className="grid grid-cols-1 gap-6 mb-8 sm:grid-cols-2 xl:grid-cols-3">
         <Card className="border-blue-200 bg-gradient-to-br from-blue-50 to-blue-100">
           <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center">
                 <Activity className="h-5 w-5 text-white" />
               </div>
@@ -438,7 +438,7 @@ export default function Dashboard() {
 
         <Card className="border-green-200 bg-gradient-to-br from-green-50 to-green-100">
           <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center">
                 <Shield className="h-5 w-5 text-white" />
               </div>
@@ -455,7 +455,7 @@ export default function Dashboard() {
 
         <Card className="border-purple-200 bg-gradient-to-br from-purple-50 to-purple-100">
           <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="w-10 h-10 bg-purple-500 rounded-full flex items-center justify-center">
                 <Clock className="h-5 w-5 text-white" />
               </div>
@@ -472,7 +472,7 @@ export default function Dashboard() {
       </div>
 
       {/* Action Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+      <div className="grid grid-cols-1 gap-6 mb-8 sm:grid-cols-2 xl:grid-cols-3">
         <Card className="hover:shadow-lg transition-shadow">
           <CardHeader>
             <div className="flex items-center space-x-3">
@@ -517,7 +517,7 @@ export default function Dashboard() {
                   <p className="text-sm text-red-600">{phoneResult.error}</p>
                 ) : (
                   <>
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
                       <p className="text-sm font-medium">
                         {phoneResult.found ? (
                           <>
@@ -536,7 +536,7 @@ export default function Dashboard() {
                           
                           return (
                             <div key={idx} className="bg-white rounded-lg border border-red-200 p-3">
-                              <div className="flex items-center justify-between">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
                                 <div className="flex items-center space-x-3">
                                   <div className="w-6 h-6 bg-red-100 rounded-full flex items-center justify-center">
                                     <AlertTriangle className="h-3 w-3 text-red-600" />
@@ -604,7 +604,7 @@ export default function Dashboard() {
                   <p className="text-sm text-red-600">{emailResult.error}</p>
                 ) : (
                   <>
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
                       <p className="text-sm font-medium">
                         {emailResult.found ? (
                           <>
@@ -623,7 +623,7 @@ export default function Dashboard() {
                           
                           return (
                             <div key={idx} className="bg-white rounded-lg border border-red-200 p-3">
-                              <div className="flex items-center justify-between">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
                                 <div className="flex items-center space-x-3">
                                   <div className="w-6 h-6 bg-red-100 rounded-full flex items-center justify-center">
                                     <AlertTriangle className="h-3 w-3 text-red-600" />
@@ -701,7 +701,7 @@ export default function Dashboard() {
               >
                 {emailBreachResult.ok ? (
                   <>
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
                       <p className="text-sm font-medium">
                         {emailBreachResult.found ? (
                           <>
@@ -727,7 +727,7 @@ export default function Dashboard() {
                           .filter((result: any) => result?.found)
                           .map((result: any, index: number) => (
                             <div key={index} className="bg-white rounded-lg border border-red-200 p-3">
-                              <div className="flex items-center justify-between">
+                              <div className="flex flex-wrap items-center justify-between gap-2">
                                 <span className="text-sm font-medium">{result.name}</span>
                                 <Badge variant="outline" className="text-xs text-red-600 border-red-300">
                                   {result.count || 0} записей
@@ -737,7 +737,7 @@ export default function Dashboard() {
                                 <p className="mt-2 text-xs text-red-600">{result.error}</p>
                               )}
                               {result.items && (
-                                <pre className="mt-3 max-h-48 overflow-y-auto rounded bg-gray-50 p-3 text-xs text-gray-700">
+                                <pre className="mt-3 max-h-48 overflow-auto rounded bg-gray-50 p-3 text-xs text-gray-700 whitespace-pre-wrap break-words">
                                   {JSON.stringify(result.items, null, 2)}
                                 </pre>
                               )}
@@ -783,7 +783,7 @@ export default function Dashboard() {
       </div>
 
       {/* Additional Services */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+      <div className="grid grid-cols-1 gap-6 mb-8 sm:grid-cols-2">
         <Card className="hover:shadow-lg transition-shadow">
           <CardHeader>
             <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- add a mobile-friendly sidebar toggle and header to the dashboard layout
- constrain the dashboard content width and update card grids to stack cleanly on small screens
- wrap leak result sections so badges and preformatted data stay readable on narrow viewports

## Testing
- pnpm --filter datatrace-web lint *(fails: next binary missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a9227438832cb73248c981c63608